### PR TITLE
fix: reads from other thread stdout

### DIFF
--- a/src/huemon/api_server.py
+++ b/src/huemon/api_server.py
@@ -5,6 +5,7 @@
 
 import contextlib
 import io
+import threading
 from typing import List
 
 from fastapi import FastAPI, HTTPException, Query, Response, status
@@ -17,6 +18,8 @@ LOG = create_logger()
 
 
 class HuemonServerFactory:  # pylint: disable=too-few-public-methods
+    __stdout_reader_mutex = threading.Lock()
+
     @staticmethod
     def __create_command_route_handler(command_handler, command_name: str):
         empty_query = Query([])
@@ -24,15 +27,16 @@ class HuemonServerFactory:  # pylint: disable=too-few-public-methods
         def handle_command_route(
             q: List[str] = empty_query,
         ):  # pylint: disable=invalid-name
-            context_reader = io.StringIO()
-            with contextlib.redirect_stdout(context_reader):
-                try:
-                    command_handler.exec(command_name, q)
-                except SystemExit as system_exit:
-                    raise HTTPException(
-                        detail=context_reader.getvalue(),
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                    ) from system_exit
+            with HuemonServerFactory.__stdout_reader_mutex:
+                context_reader = io.StringIO()
+                with contextlib.redirect_stdout(context_reader):
+                    try:
+                        command_handler.exec(command_name, q)
+                    except SystemExit as system_exit:
+                        raise HTTPException(
+                            detail=context_reader.getvalue(),
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                        ) from system_exit
 
             return Response(context_reader.getvalue(), media_type="plain/text")
 


### PR DESCRIPTION
Sometimes stdout-results from different threads would be combined when requests overlapped, which resulted in wrong discoveries and values.

Not adding any tests, because this whole issue will disappear after the implementation of https://github.com/edeckers/huemon/issues/41