### PR TITLE
fix: release image to ghrc.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Huemon
 
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
-[![Build](https://github.com/edeckers/huemon/actions/workflows/test.yml/badge.svg)](https://github.com/edeckers/huemon/actions/workflows/test.yml)
+[![Build](https://github.com/edeckers/huemon/actions/workflows/test.yml/badge.svg?branch=develop)](https://github.com/edeckers/huemon/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/huemon.svg?maxAge=3600)](https://pypi.org/project/huemon)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: "2.3"
 
 services:
   huemon:
-    image: edeckers/huemon:0.8.0
+    image: ghrc.io/edeckers/huemon:0.8.0
     volumes:
     - huemon-config:/etc/huemon
     - huemon-opt:/opt/huemon


### PR DESCRIPTION
BREAKING CHANGE:
Images are now released through ghrc.io instead of DockerHub